### PR TITLE
This should correct your issue

### DIFF
--- a/client/app/main/main.controller.js
+++ b/client/app/main/main.controller.js
@@ -27,7 +27,7 @@ angular.module('conwaysgameoflifeApp')
     //Start the game
     $scope.play = function() {
       game.stillAlive = true;
-      continuous(game);
+      continuous();
     };
 
     function continuous() {
@@ -36,7 +36,7 @@ angular.module('conwaysgameoflifeApp')
         console.log("got into the if statement");
         game = logic.iterate(game);
         $scope.grid = game.grid;
-        $timeout(continuous(), 1000);
+        $timeout(continuous, 1000);
       }
     }
 


### PR DESCRIPTION
when passing functions as parameters that will execute the function you pass as reference, if you execute the function inline it will pass the value or result of execution:

`$timeout(fn, t)` 

if you pass `$timeout(fn(), 10)` is like `$timeout(null, 10)`
